### PR TITLE
Feature: Continuous Specification Analysis (Issue #6)

### DIFF
--- a/.github/workflows/speckit-analyze-agents.yml
+++ b/.github/workflows/speckit-analyze-agents.yml
@@ -1,0 +1,78 @@
+name: Speckit Analyze (Agents)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/vindicta-agents/specs/**'
+      - 'packages/vindicta-agents/features/**'
+      - 'packages/vindicta-agents/src/**'
+      - 'packages/vindicta-agents/tests/**'
+      - 'docs/constitution.md'
+      - 'scripts/speckit_analyze.py'
+      - '.github/workflows/speckit-analyze-agents.yml'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Cache Ollama models
+        uses: actions/cache@v4
+        with:
+          path: ~/.ollama
+          key: ${{ runner.os }}-ollama-phi3
+          restore-keys: |
+            ${{ runner.os }}-ollama-
+
+      - name: Start Ollama service
+        run: |
+          curl -fsSL https://ollama.com/install.sh | sh
+          ollama serve &
+          sleep 5
+          ollama pull phi3 || true
+
+      - name: Run Tests to Generate Context
+        working-directory: packages/vindicta-agents
+        run: |
+          uv sync --all-extras
+          uv run behave -f json -o behave_report.json || true
+          uv run pytest > pytest_report.txt || true
+        continue-on-error: true
+
+      - name: Setup Node.js (for repomix)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Initialize Spec Kit
+        working-directory: packages/vindicta-agents
+        run: |
+          uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+          specify init --here --ai generic --script sh --force
+
+      - name: Package Context with Repomix
+        working-directory: packages/vindicta-agents
+        run: |
+          npx -y repomix --include "specs/**/*.md,features/**/*.feature,behave_report.json,pytest_report.txt,../../docs/constitution.md,../../.github/workflows/speckit-analyze-agents.yml" --ignore "src/**,tests/**,node_modules/**,.venv/**" -o repomix_context.xml
+
+      - name: Run Speckit Analysis
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uv run --with PyGithub --with ollama python scripts/speckit_analyze.py

--- a/scripts/speckit_analyze.py
+++ b/scripts/speckit_analyze.py
@@ -1,0 +1,92 @@
+import os
+import json
+import logging
+from github import Github
+import ollama
+
+logging.basicConfig(level=logging.INFO)
+
+def main():
+    repo_name = os.environ.get("GITHUB_REPOSITORY")
+    github_token = os.environ.get("GITHUB_TOKEN")
+    
+    if not github_token or not repo_name:
+        logging.error("Missing GITHUB_REPOSITORY or GITHUB_TOKEN.")
+        return
+
+    context_path = "packages/vindicta-agents/repomix_context.xml"
+    if not os.path.exists(context_path):
+        logging.error(f"Context file {context_path} not found.")
+        return
+
+    with open(context_path, "r", encoding="utf-8") as f:
+        repomix_context = f.read()
+
+    prompt = f"""
+You are an automated code and specification analyzer for the Vindicta platform.
+Your job is to read the attached code context (which includes the project constitution, specifications, test reports, and the `.github/workflows/speckit-analyze-agents.yml` CI definition).
+Identify any "drift" - where the test reports indicate the specifications and acceptance criteria are unfulfilled or failing.
+Pay extreme attention to the rules defined in constitution.md and ensure our pipeline conforms to the configurations defined in the workflow file.
+
+If drift or violations are found, output a JSON array of issues to be created.
+If no drift is found, output an empty JSON array `[]`.
+
+Format STRICTLY as a JSON array of objects. Example:
+[
+  {{
+    "title": "Drift Detected: <short title>",
+    "body": "<Detailed explanation of the drift and failed acceptance criteria>"
+  }}
+]
+
+DO NOT include any markdown blocks around the JSON output. DO NOT include any explanatory text before or after the JSON.
+
+Context:
+{repomix_context}
+"""
+
+    logging.info("Calling Ollama (phi3)...")
+    try:
+        response = ollama.chat(
+            model="phi3",
+            messages=[{"role": "user", "content": prompt}],
+            format="json",
+            options={"temperature": 0.0}
+        )
+        content = response['message']['content'].strip()
+        
+        try:
+            issues = json.loads(content)
+        except json.JSONDecodeError:
+            logging.error(f"Failed to parse JSON response. Response was: {content}")
+            return
+            
+        if not isinstance(issues, list):
+            logging.error(f"JSON response is not a list. Response was: {content}")
+            return
+
+        if len(issues) == 0:
+            logging.info("No drift detected.")
+            return
+            
+        logging.info(f"Found {len(issues)} drift issues.")
+        
+        g = Github(github_token)
+        repo = g.get_repo(repo_name)
+        
+        for issue in issues:
+            title = issue.get("title", "Detected Specification Drift")
+            body = issue.get("body", "Drift was detected by local speckit analysis, but no details were provided.")
+            
+            repo.create_issue(
+                title=title,
+                body=body,
+                labels=["quality", "speckit.analyze"]
+            )
+            logging.info(f"Created issue: {title}")
+            
+    except Exception as e:
+        logging.error(f"Error during analysis: {e}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
Implements [Issue #6](https://github.com/vindicta-platform/vindicta-platform/issues/6).

This PR introduces a GitHub Action to trigger continuous analysis of standard repository documentation and features to detect drift or un-fulfilled definitions.

## Changes Made
- Added `.github/workflows/speckit-analyze-agents.yml` to run testing and package a specific codebase context using `repomix`.
- The action installs `specify-cli` natively from `github/spec-kit` and initializes a headless, script-friendly configuration (`specify init --here --ai generic --script sh --force`).
- Added Python analysis script (`scripts/speckit_analyze.py`) which evaluates test outcomes (`behave`, `pytest`) against the context of `.md` features/specs and `constitution.md`.
- Updated submodule `pyproject.toml` files to use `workspace = true` for `vindicta-foundation` to fix UV dependency resolution during CI.
