### PR TITLE
feat: add broken link checker and docker build workflows

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -1,0 +1,102 @@
+name: Broken Link Checker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '**/*.md'
+  schedule:
+    - cron: '0 5 * * 3'
+  workflow_dispatch:
+
+concurrency:
+  group: link-check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Check Documentation Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Init submodules
+        run: git submodule update --init --recursive --depth 1 || true
+
+      - name: Check external links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >
+            --verbose
+            --no-progress
+            --accept 100..399
+            --exclude-mail
+            --exclude 'localhost'
+            --exclude '127.0.0.1'
+            --exclude 'example.com'
+            --exclude 'github.com/vindicta-platform/.*/pull'
+            --exclude 'github.com/vindicta-platform/.*/issues'
+            --timeout 30
+            --max-retries 2
+            --max-concurrency 5
+            'docs/**/*.md'
+            'README.md'
+            'CONTRIBUTING.md'
+            'packages/*/README.md'
+          output: link-check-report.md
+          fail: false
+
+      - name: Post summary
+        if: always()
+        run: |
+          echo '### 🔗 Link Check Report' >> $GITHUB_STEP_SUMMARY
+          if [ -f link-check-report.md ]; then
+            cat link-check-report.md >> $GITHUB_STEP_SUMMARY
+          else
+            echo '✅ No broken links found' >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Create issue on broken links
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('link-check-report.md')) return;
+            const report = fs.readFileSync('link-check-report.md', 'utf8');
+            if (!report.includes('Errors')) return;
+
+            // Close previous link-check issues
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              labels: 'documentation,automated', state: 'open'
+            });
+            for (const issue of issues) {
+              if (issue.title.includes('Broken Link')) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: issue.number, state: 'closed',
+                  state_reason: 'not_planned'
+                });
+              }
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner, repo: context.repo.repo,
+              title: `🔗 Broken Links Detected — ${new Date().toISOString().slice(0, 10)}`,
+              body: `## Broken Link Report\n\n${report.slice(0, 60000)}`,
+              labels: ['documentation', 'automated']
+            });
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: link-check-report
+          path: link-check-report.md
+          retention-days: 14

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,97 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docker-compose.yml'
+      - 'Dockerfile'
+      - '.devcontainer/**'
+      - 'packages/*/Dockerfile'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docker-compose.yml'
+      - 'Dockerfile'
+      - '.devcontainer/**'
+      - 'packages/*/Dockerfile'
+  workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build Container Images
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - context: .
+            image: vindicta-platform
+            dockerfile: Dockerfile
+          - context: .
+            image: vindicta-devcontainer
+            dockerfile: .devcontainer/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for Dockerfile
+        id: check
+        run: |
+          if [ -f "${{ matrix.dockerfile }}" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "::notice::${{ matrix.dockerfile }} not found, skipping"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: steps.check.outputs.exists == 'true' && github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        if: steps.check.outputs.exists == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/vindicta-platform/${{ matrix.image }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push
+        if: steps.check.outputs.exists == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image summary
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          echo '### 🐳 Docker Build' >> $GITHUB_STEP_SUMMARY
+          echo '- **Image:** `ghcr.io/vindicta-platform/${{ matrix.image }}`' >> $GITHUB_STEP_SUMMARY
+          echo '- **Dockerfile:** `${{ matrix.dockerfile }}`' >> $GITHUB_STEP_SUMMARY
+          echo '- **Push:** ${{ github.event_name != 'pull_request' }}' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Adds two new monorepo-specific workflows:

### 1. Broken Link Checker (`broken-link-checker.yml`)
- Uses lychee for fast external link checking across all docs
- Runs on push to docs, weekly Wednesday, and manual dispatch
- Auto-creates a GitHub issue when broken links are detected
- Closes previous broken-link issues to avoid duplicates

### 2. Docker Build (`docker-build.yml`)
- Matrix build for multiple Dockerfiles (root + devcontainer)
- Pushes to GHCR on main push, build-only on PRs
- Uses Docker layer caching via GHA cache
- Gracefully skips if Dockerfiles don't exist yet